### PR TITLE
Api root fix

### DIFF
--- a/create_invoice.html
+++ b/create_invoice.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
   </head>
   <body>
-    <form method=POST action=/api/create_invoice>
+    <form method=POST action=api/create_invoice>
       <input name="amount_sat" placeholder="amount (satoshis)">
       <input name="message" placeholder="message">
       <input type=submit value="Submit">

--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ function getUrlParameter(sParam)
 var id = getUrlParameter('id');
 
 if (id) {
-    var jqxhr = $.getJSON("/api/get_invoice?" +  id, function() {
+    var jqxhr = $.getJSON("api/get_invoice?" +  id, function() {
         console.log("getJSON:success");
     })
     .done( function(data) {
@@ -105,7 +105,7 @@ if (id) {
              }
         });
 
-        var wss_address = (document.URL.startsWith("https") ? "wss" : "ws") + "://" + window.location.host +"/api/get_status?" + id;
+        var wss_address = document.URL.replace("http", "ws").match("(.*)/")[1] +  "/api/get_status?" + id;
         console.log("Opening WSS: " + wss_address)
         var ws = new WebSocket(wss_address);
         var received_msg;


### PR DESCRIPTION
These are the necessary changes for [the proposed update to the API endpoint](https://github.com/spesmilo/electrum/pull/6454) to be under `{payserver_root}/api/` as opposed to `/api/`. This properly allows the Electrum payserver to be used in a section container inside of another service that controls the `/api/` endpoint (i.e. `example.com/donate/api`)